### PR TITLE
ci: bump github action/checkout to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,13 @@ jobs:
           - '1.20'
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go ${{ matrix.go }}
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ matrix.go }}
-
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
+
+      - name: Set up Go ${{ matrix.go }}
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go }}
 
       - name: Go build
         run: make

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           go-version: ${{ matrix.go }}
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Go build
         run: make
@@ -44,7 +44,7 @@ jobs:
           - v1.26.0
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up KIND cluster
         uses: engineerd/setup-kind@v0.5.0


### PR DESCRIPTION
Bump GitHub actions because the Node.js 12 actions are deprecated.
- action/checkout@v3
- action/setup-go@v4