### PR TITLE
ci: install kustomize without calling the GitHub API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,12 +71,24 @@ jobs:
           image: "kindest/node:${{ matrix.k8s }}"
           name: "${{ steps.cluster_name.outputs.name }}"
 
+      # Download the release asset directly instead of running upstream's
+      # install_kustomize.sh, which queries the GitHub API to resolve the
+      # release. Seventeen matrix jobs hitting that endpoint at once is enough
+      # to get rate-limited on its own, and on Dependabot pull requests it is
+      # guaranteed: Dependabot cannot read repository secrets, so GHCR_TOKEN is
+      # empty and every request goes out unauthenticated.
       - name: Install kustomize
         env:
-          GITHUB_TOKEN: ${{ secrets.GHCR_TOKEN }}
+          KUSTOMIZE_VERSION: v4.5.7
+          KUSTOMIZE_SHA256: 701e3c4bfa14e4c520d481fdf7131f902531bfc002cb5062dcf31263a09c70c9
         run: |
-          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/kustomize/v5.0.3/hack/install_kustomize.sh" | bash -s -- 4.5.7
-          sudo mv kustomize /usr/local/bin/kustomize
+          set -euo pipefail
+          url="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
+          curl -sSfL --retry 3 --retry-delay 5 -o kustomize.tar.gz "$url"
+          echo "${KUSTOMIZE_SHA256}  kustomize.tar.gz" | sha256sum -c -
+          tar -xzf kustomize.tar.gz kustomize
+          sudo install -m 0755 kustomize /usr/local/bin/kustomize
+          kustomize version
 
       - name: E2E Test
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      # One flaky job should not cancel the other sixteen. Without this, a
+      # single infrastructure hiccup leaves every other Kubernetes version
+      # reported as "cancelled", which says nothing about whether they pass.
+      fail-fast: false
       matrix:
         k8s:
           - v1.19.16


### PR DESCRIPTION
## Why

Dependabot PRs fail on `test (...)` with a failure that has nothing to do with the change under test — for example #236 (a logrus bump):

```
Github rate-limiter failed the request. Either authenticate or wait a couple of minutes.
##[error]Process completed with exit code 1.
```

The `Install kustomize` step runs upstream's `install_kustomize.sh`, which **queries the GitHub API** to resolve the release. Two things make that call fail:

- It is passed `GITHUB_TOKEN: ${{ secrets.GHCR_TOKEN }}`. **Dependabot pull requests cannot read repository secrets**, so on those runs the token is empty and every request goes out unauthenticated. This is not intermittent for Dependabot — it is structural.
- Seventeen matrix jobs hit the same endpoint simultaneously, which is enough to trip the rate limiter on its own even when a token is present.

## What changed

**1. Install kustomize from the release asset directly** — no API call, so no token is needed at all. The tarball is checksum-verified, which also makes the step pinned rather than resolved at run time:

```
701e3c4bfa14e4c520d481fdf7131f902531bfc002cb5062dcf31263a09c70c9  kustomize_v4.5.7_linux_amd64.tar.gz
```

That value is the one published in the release's own `checksums.txt`. The installed version is unchanged (`v4.5.7`).

**2. `fail-fast: false` on the test matrix** — currently one failure cancels the other sixteen, so a single flake hides every other result. **This one is separable**: drop the second commit if the cancellation is deliberate.

## Verification

The new step was executed in an `ubuntu:24.04` container, not just eyeballed:

```
kustomize.tar.gz: OK
{Version:kustomize/v4.5.7 GitCommit:56d82a8378dfc8dc3b3b1085e5a6e67b82966bd7 BuildDate:2022-08-02T16:35:54Z GoOs:linux GoArch:amd64}
```

Checksum verified, binary installed, same version as before.

## Note on #236

#236 itself is fine — the `go.mod`/`go.sum` bump is correct and all `build` jobs pass. Once this merges, `@dependabot rebase` on that PR should turn it green. The fix deliberately does **not** go on the Dependabot branch, since editing it stops Dependabot from managing the PR.